### PR TITLE
docs: drop testcases.list() prompt fetch, promote testcase= flow

### DIFF
--- a/concepts/overview.mdx
+++ b/concepts/overview.mdx
@@ -55,12 +55,12 @@ A **mutation** is a tracked change to the env (a database write, a file change) 
 
 A **testcase** is a pre-defined task: prompt, target sim(s), starting artifacts, scoring config. They live in your Plato tenant with public IDs like `"tc_abc123"`.
 
+**Starting a session from a testcase is the easiest path.** `plato.sessions.create(testcase="tc_abc123")` provisions the right envs, links the scoring config, and auto-resets — `session.evaluate()` then just works. Sessions created from `envs=` need a manual `reset()` and a `session.link_testcase("tc_abc123")` before `evaluate()` will score.
+
 `session.evaluate()` scores the session against the linked testcase. Two scoring modes; a testcase can use one or both:
 
 - **MUTATION** — the testcase declares the database/file changes a successful run must produce. `evaluate()` reads the env's mutation stream and checks them.
 - **OUTPUT** — the agent must return a JSON object matching a schema declared on the testcase. Pass it as `evaluate(value=...)`.
-
-Sessions created from `testcase=` are linked automatically. Sessions created from `envs=` aren't until you call `session.link_testcase("tc_abc123")`.
 
 ## Public URLs vs liveview
 

--- a/sdk-v2/examples.mdx
+++ b/sdk-v2/examples.mdx
@@ -56,6 +56,12 @@ finally:
 
 The canonical end-to-end pattern. Spin a session from a testcase, reset to start mutation logging, log into the apps, run your agent, score.
 
+<Tip>
+**Start sessions from a testcase whenever you can.** `plato.sessions.create(testcase=...)` provisions the right envs, links the scoring config, and auto-resets — `session.evaluate()` then just works. Sessions created from `envs=` need manual `reset()` and `link_testcase(...)` before `evaluate()` will score.
+</Tip>
+
+You need to know the testcase's public ID (e.g. `"tc_abc123"`) and the prompt the agent should run against — both come from the testcase's page in the [Plato dashboard](https://plato.so).
+
 The login call depends on whether the testcase includes a desktop env — branch on `session.desktop_env`.
 
 ```python
@@ -64,12 +70,10 @@ from playwright.sync_api import sync_playwright
 from plato.v2 import Plato
 
 plato = Plato()
-testcase_id = "tc_abc123"
 
-# Pull the prompt — sessions.create doesn't expose it.
-response = plato.testcases.list()
-tc = next(t for t in response.testcases if t["publicId"] == testcase_id)
-prompt = tc["prompt"]
+# From the testcase's page in the Plato dashboard:
+testcase_id = "tc_abc123"
+prompt = "..."   # the task instructions you'll give to the agent
 
 session = plato.sessions.create(testcase=testcase_id)
 desktop = session.desktop_env


### PR DESCRIPTION
## Summary

- Examples #4 (full evaluation) no longer fetches the prompt via `plato.testcases.list()`. Readers grab the ID + prompt from the testcase's page in the Plato dashboard instead — fewer moving parts in the canonical example.
- New **Tip** in Examples #4 and a new paragraph in **Concepts → Testcases** explicitly recommend starting sessions from `testcase=`: envs, scoring link, and auto-reset all happen for free.

## Test plan

- [ ] Mintlify preview renders Examples #4 with the new Tip block
- [ ] Concepts → Testcases reads as a clear pitch for the `testcase=` path
- [ ] No broken cross-links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is minor reader confusion if the dashboard-derived prompt/ID instructions don’t match current UI.
> 
> **Overview**
> Promotes **creating sessions from `testcase=`** as the preferred workflow, clarifying that it provisions envs, links scoring, and auto-resets so `session.evaluate()` works without extra setup.
> 
> Simplifies the *Full evaluation* example by removing the `plato.testcases.list()` prompt fetch and instead instructing readers to take the testcase ID and prompt from the Plato dashboard, and adds a `Tip` callout reinforcing the `testcase=` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73adc5e565f519d3c5872e7f75c491cde71a2486. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->