### PR TITLE
correct

### DIFF
--- a/sdk-v2/examples.mdx
+++ b/sdk-v2/examples.mdx
@@ -92,7 +92,7 @@ try:
 
     result = session.evaluate()                  # 4. score
     # For OUTPUT scoring: result = session.evaluate(value={"answer": "..."})
-    print(f"success={result.success}  score={result.score}")
+    print(f"correct={result.correct}  score={result.score}")
 finally:
     session.close()
     plato.close()

--- a/sdk-v2/sessions.mdx
+++ b/sdk-v2/sessions.mdx
@@ -49,7 +49,7 @@ Score the session against its linked testcase. `value` is required for OUTPUT sc
 
 ```python
 result = session.evaluate()
-print(result.success, result.score)
+print(result.correct, result.score)
 ```
 
 ### `get_public_url(port=None)`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only field rename in example snippets; no runtime or API implementation changes in this diff.
> 
> **Overview**
> Updates SDK v2 documentation so **`session.evaluate()`** examples use **`result.correct`** instead of **`result.success`**, matching the current evaluation result API.
> 
> Changes appear in the full evaluation walkthrough (`examples.mdx`) and the `evaluate()` reference (`sessions.mdx`); scoring behavior and `result.score` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28977d0b3ce9c0f24ad192d1d6391daa1d8febf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->