### PR TITLE
docs: remove link_testcase from public docs

### DIFF
--- a/concepts/overview.mdx
+++ b/concepts/overview.mdx
@@ -41,7 +41,7 @@ Every Plato run follows the same five steps:
 2. **Login** — `desktop.sdk.login(session)` for desktop sessions, `session.login(browser)` for app-sim sessions. Login mutations are captured by the stream.
 3. **Run the agent** — drive the env however the task requires.
 4. **`session.get_state()`** — *(optional)* peek at mutations mid-run.
-5. **`session.evaluate()`** — score the session against its linked testcase.
+5. **`session.evaluate()`** — score the session against its testcase.
 
 For a working example: [Core SDK → Examples](/sdk-v2/examples).
 
@@ -55,9 +55,9 @@ A **mutation** is a tracked change to the env (a database write, a file change) 
 
 A **testcase** is a pre-defined task: prompt, target sim(s), starting artifacts, scoring config. They live in your Plato tenant with public IDs like `"tc_abc123"`.
 
-**Starting a session from a testcase is the easiest path.** `plato.sessions.create(testcase="tc_abc123")` provisions the right envs, links the scoring config, and auto-resets — `session.evaluate()` then just works. Sessions created from `envs=` need a manual `reset()` and a `session.link_testcase("tc_abc123")` before `evaluate()` will score.
+**Starting a session from a testcase is the only path to scoring.** `plato.sessions.create(testcase="tc_abc123")` provisions the right envs, links the scoring config, and auto-resets — `session.evaluate()` then just works. Sessions created from `envs=` are for free-form work and cannot be evaluated.
 
-`session.evaluate()` scores the session against the linked testcase. Two scoring modes; a testcase can use one or both:
+`session.evaluate()` scores the session against its testcase. Two scoring modes; a testcase can use one or both:
 
 - **MUTATION** — the testcase declares the database/file changes a successful run must produce. `evaluate()` reads the env's mutation stream and checks them.
 - **OUTPUT** — the agent must return a JSON object matching a schema declared on the testcase. Pass it as `evaluate(value=...)`.
@@ -85,6 +85,6 @@ Every API has a sync (`Plato`) and async (`AsyncPlato`) form — same names, jus
 | **Mutation** | A tracked change (db write, file change) since the last reset. |
 | **Reset** | Initialize mutation logging on each sim. |
 | **Testcase** | A pre-defined task: prompt + envs + scoring config. |
-| **Evaluate** | Score a session against its linked testcase. |
+| **Evaluate** | Score a session against its testcase. |
 | **Liveview** | noVNC URL to watch a desktop VM in real time. |
 | **Mesh** | Per-session WireGuard network connecting all envs at `{alias}.plato.internal`. |

--- a/sdk-v2/examples.mdx
+++ b/sdk-v2/examples.mdx
@@ -57,7 +57,7 @@ finally:
 The canonical end-to-end pattern. Spin a session from a testcase, reset to start mutation logging, log into the apps, run your agent, score.
 
 <Tip>
-**Start sessions from a testcase whenever you can.** `plato.sessions.create(testcase=...)` provisions the right envs, links the scoring config, and auto-resets — `session.evaluate()` then just works. Sessions created from `envs=` need manual `reset()` and `link_testcase(...)` before `evaluate()` will score.
+**Always start scored sessions from the testcase.** `plato.sessions.create(testcase=...)` provisions the right envs (desktop envs included), links the scoring config, and auto-resets — `session.evaluate()` then just works. Sessions created from `envs=` or `artifacts=` cannot be evaluated.
 </Tip>
 
 You need to know the testcase's public ID (e.g. `"tc_abc123"`) and the prompt the agent should run against — both come from the testcase's page in the [Plato dashboard](https://plato.so).

--- a/sdk-v2/sessions.mdx
+++ b/sdk-v2/sessions.mdx
@@ -23,6 +23,8 @@ session = plato.sessions.create(envs=[...], timeout=3600)
 
 `testcase=` auto-resets. `envs=` does not — call `session.reset()` first thing yourself.
 
+To score a run with `evaluate()`, create the session with `testcase=` — it provisions the testcase's envs and links the scoring config in one step. Sessions created from `envs=` or `artifacts=` cannot be evaluated.
+
 ## Operations
 
 ### `reset()`
@@ -45,7 +47,7 @@ for job_id, env_state in state.results.items():
 
 ### `evaluate(value=None)`
 
-Score the session against its linked testcase. `value` is required for OUTPUT scoring; omit for MUTATION-only.
+Score the session against its testcase. Only sessions created with `testcase=` can be evaluated — the testcase carries the scoring config. `value` is required for OUTPUT scoring; omit for MUTATION-only.
 
 ```python
 result = session.evaluate()
@@ -59,14 +61,6 @@ Browser-accessible URLs per env, keyed by alias.
 ```python
 urls = session.get_public_url()
 # {"crm": "https://abc123--80.sims.plato.so", ...}
-```
-
-### `link_testcase(testcase_id)`
-
-Link a testcase to a session created from `envs=` so `evaluate()` has scoring config to read.
-
-```python
-session.link_testcase("tc_abc123")
 ```
 
 ### `login(browser)` / desktop login


### PR DESCRIPTION
## Why

The `link-testcase` endpoint is now restricted to Plato-internal use — external orgs get `403 ForbiddenError`. But the public docs actively documented `session.link_testcase()` as the way to score sessions created from `envs=`/`artifacts=`, which is exactly the flow a customer's Windows env-creation harness followed (create from env artifacts → link testcase → evaluate), and it's now breaking their runs.

## What

- **`sdk-v2/sessions.mdx`** — removed the `link_testcase(testcase_id)` reference section; `evaluate()` and the Creating section now state that only sessions created with `testcase=` can be evaluated.
- **`sdk-v2/examples.mdx`** — the Tip no longer offers `link_testcase(...)` as the fallback for `envs=` sessions; scored sessions must start from the testcase.
- **`concepts/overview.mdx`** — same change to the testcase/scoring section, plus "linked testcase" phrasing cleaned up so nothing implies a manual linking step.

The supported external flow is now solely `plato.sessions.create(testcase="tc_...")`, which provisions the testcase's envs (desktop included), links scoring config, and auto-resets server-side.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modified in this PR.
> 
> **Overview**
> Public docs no longer describe **`session.link_testcase()`** or any way to score sessions started from **`envs=`** / **`artifacts=`**, matching the API restriction (external orgs get 403 on link-testcase).
> 
> **`sdk-v2/sessions.mdx`** drops the `link_testcase` reference section and states that **`evaluate()`** only works when the session was created with **`testcase=`**. **`sdk-v2/examples.mdx`** and **`concepts/overview.mdx`** align: scored runs must use **`plato.sessions.create(testcase=...)`**; free-form **`envs=`** sessions are documented as non-evaluable. Wording shifts from “linked testcase” to “its testcase” so nothing implies a manual link step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241595c63207b7f64067941f2e9603dba9a915d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->